### PR TITLE
improve selected dot logic for infinity carousel

### DIFF
--- a/examples/main.stories.tsx
+++ b/examples/main.stories.tsx
@@ -183,6 +183,41 @@ export function NoCenterAutoplay() {
   );
 }
 
+export function NoCenterInfinity() {
+  return (
+    <Box sx={{ p: 5, width: "100%", boxSizing: "border-box" }}>
+      <Carousel
+        {...getCommonProps()}
+        sx={{
+          mt: 3,
+          [`& .${carouselClasses.dots}`]: {
+            mt: 5,
+          },
+          [`& .${carouselClasses.item} > *`]: {
+            transition: "all 0.5s",
+          },
+          [`& .${carouselClasses.center} > *`]: {
+            transform: "scale(1.2)",
+          },
+        }}
+        dots={true}
+        spacing={4}
+        autoPlay
+        infinity
+      >
+        {new Array(3).fill(0).map((_, i) => (
+          <Paper
+            key={`item-${i}`}
+            sx={{ height: 200, background: "#fafafa", m: 3 }}
+          >
+            Item: {i}
+          </Paper>
+        ))}
+      </Carousel>
+    </Box>
+  );
+}
+
 export function Infinity() {
   return (
     <Box sx={{ p: 5, width: "100%", boxSizing: "border-box" }}>

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -125,7 +125,7 @@ function Carousel({
     });
     next = React.cloneElement(next, {
       ...next.props,
-      onClick: carousel.nextSlide,
+      ...(carousel.hiddenNextArrow ? {} : { onClick: carousel.nextSlide }),
       className: clsx(
         carouselClasses.arrow,
         { [carouselClasses.arrowDisabled]: carousel.hiddenNextArrow },
@@ -140,7 +140,7 @@ function Carousel({
     });
     prev = React.cloneElement(prev, {
       ...prev.props,
-      onClick: carousel.prevSlide,
+      ...(carousel.hiddenPrevArrow ? {} : { onClick: carousel.prevSlide }),
       className: clsx(
         carouselClasses.arrow,
         { [carouselClasses.arrowDisabled]: carousel.hiddenPrevArrow },
@@ -156,10 +156,11 @@ function Carousel({
       const offset =
         props.centerMode && !props.infinity ? Math.floor(showSlides / 2) : 0;
 
+      const isSlideIndexNegative = carousel.slide < 0;
+      const absoluteSlideIndex = Math.abs(carousel.slide) % rows.length;
+
       el = renderDot({
-        selected: props.centerMode
-          ? (i + offset) % rows.length === carousel.centerIndex % rows.length
-          : i === carousel.slide,
+        selected: absoluteSlideIndex !== 0 && isSlideIndexNegative ? rows.length - i === absoluteSlideIndex : i === absoluteSlideIndex,
         index: i + offset,
       });
       el = React.cloneElement(el, {


### PR DESCRIPTION
Hi,

Thank you for the carousel you've built, I love it so much.

When the library passes disabled flag to `prev` and `next` elements they still handle `onClick` event despite their state being disabled. I wonder what you think if we remove `onClick` handler from the elements when they are disabled.

The demo: 
https://user-images.githubusercontent.com/5417051/209243723-913165fe-d21f-464f-86e0-ce5aa01ff024.mp4

In a project I worked, we use circled dots, so it's not convenient to manage disabled state in custom components.

Again, the configuration of our carousel is a bit interesting, we use`noCenter` , `infinity` and `dots` settings. In this configuration dots don't get marked as selected properly and infinity carousel doesn't show dots when you go beyond the limits.

The demo:

https://user-images.githubusercontent.com/5417051/209246138-000d9725-60de-4473-bb6d-2dc33091d5d4.mp4


After applying the patch:

https://user-images.githubusercontent.com/5417051/209244825-97209da7-1ad2-493e-adef-8223ce6276d7.mp4



